### PR TITLE
記事生成 MVP (R1) 実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename to .env.local and fill your keys
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/ai-sdk.md
+++ b/docs/ai-sdk.md
@@ -41,6 +41,10 @@ export async function POST(req: Request) {
   });
 
   // Next.js 用 SSE 変換
+> **重要**: `useCompletion` で `streamProtocol: 'text'` を指定した場合、
+> API ルートは `toTextStreamResponse()` を返す必要があります。 `toDataStreamResponse()` と
+> 組み合わせると UI で `f:{"messageId":...}` のような生データが表示されるため注意してください。
+
   return result.toDataStreamResponse();
 }
 ```

--- a/docs/ai-sdk.md
+++ b/docs/ai-sdk.md
@@ -1,0 +1,114 @@
+# Vercel AI SDK 利用ガイド
+
+このドキュメントでは、記事生成アプリで利用する **Vercel AI SDK** の基本的な使い方をまとめます。
+
+## 1. 概要
+Vercel AI SDK は複数の AI モデルプロバイダー（OpenAI, Anthropic など）を共通 API で扱える TypeScript ツールキットです。フック（UI）とコア（生成）で構成されています。
+
+- **ai** … コア API (`generateText`, `streamText`, `generateObject` など)
+- **@ai-sdk/react** … フック (`useCompletion`, `useChat`, `useObject` など)
+- **@ai-sdk/<provider>** … 各プロバイダーアダプター
+
+## 2. 依存パッケージの追加
+```bash
+# ルートで一度だけ
+npm install ai @ai-sdk/openai @ai-sdk/react
+```
+
+## 3. 環境変数
+`.env.local` に OpenAI キーを追加してください。
+```
+OPENAI_API_KEY=sk-...
+```
+
+## 4. API ルート実装例
+`src/app/api/generate/route.ts`
+```ts
+import { streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+export const runtime = 'edge'; // Vercel Edge Functions
+
+export async function POST(req: Request) {
+  const { overview, formatPrompt } = await req.json();
+
+  const result = streamText({
+    model: openai('gpt-4o'),
+    system: 'あなたはプロの編集者です。',
+    prompt: `${formatPrompt}\n---\n概要: ${overview}`,
+    temperature: 0.8,
+    maxTokens: 2048,
+  });
+
+  // Next.js 用 SSE 変換
+  return result.toDataStreamResponse();
+}
+```
+
+## 5. クライアント側 (useCompletion)
+`src/app/(pages)/article/page.tsx`
+```tsx
+'use client';
+import { useCompletion } from '@ai-sdk/react';
+
+export default function ArticleGenerator() {
+  const { completion, input, handleInputChange, handleSubmit, status } =
+    useCompletion({
+      api: '/api/generate',
+      body: { formatPrompt: 'ブログ書式' },
+      onError: console.error,
+    });
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <textarea
+        value={input}
+        onChange={handleInputChange}
+        placeholder="記事概要を入力 (10文字以上)"
+        minLength={10}
+      />
+      <button disabled={status !== 'ready'}>生成</button>
+      <pre className="whitespace-pre-wrap border p-4 max-h-96 overflow-auto">
+        {completion}
+      </pre>
+    </form>
+  );
+}
+```
+
+## 6. JSON 構造化出力 (generateObject)
+```ts
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const schema = z.object({
+  title: z.string(),
+  body: z.string(),
+  tags: z.array(z.string()),
+});
+
+const { object } = await generateObject({
+  model: openai('gpt-4o'),
+  schema,
+  prompt: '...' // 詳細プロンプト
+});
+```
+
+## 7. 複数モデルの切替
+```ts
+import { openai } from '@ai-sdk/openai';
+import { anthropic } from '@ai-sdk/anthropic';
+
+const model = selectedProvider === 'anthropic'
+  ? anthropic('claude-3')
+  : openai('gpt-4o');
+```
+
+## 8. よくあるエラー
+|状況|対応策|
+|---|---|
+|401 Unauthorized|API キーが正しいか、環境変数がデプロイに反映されているか確認|
+|429 Rate limit|リトライ、トークン量削減、プロンプト短縮|
+
+---
+以上

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -84,6 +84,8 @@
 - ホスティング: Vercel (Edge Functions 利用可)
 - 使用言語: TypeScript, Next.js 14 (app router)
 - AI SDK: `@vercel/ai` を必須利用
+- **ストリーミング種別ルール**: `useCompletion` フック側の `streamProtocol` と API ルートの `to*StreamResponse()` は必ず対応させること (`text` ↔ `toTextStreamResponse`, `data` ↔ `toDataStreamResponse`)。
+
 - モデル登録時、ユーザー責任でライセンス遵守
 
 ## 9. 画面一覧 (概要)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "next": "15.3.3",
+    "ai": "^1.0.0",
+    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/react": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -6,12 +6,15 @@ export const runtime = 'edge';
 
 export async function POST(req: Request) {
   try {
-    const { overview, formatId } = (await req.json()) as {
-      overview: string;
+    const { overview, prompt, formatId } = (await req.json()) as {
+      overview?: string;
+      prompt?: string;
       formatId: string;
     };
 
-    if (typeof overview !== 'string' || overview.length < 10) {
+    const ov = overview ?? prompt ?? '';
+
+    if (ov.length < 10) {
       return new Response('overview must be at least 10 characters', {
         status: 400,
       });
@@ -22,7 +25,7 @@ export async function POST(req: Request) {
     const result = streamText({
       model: openai('gpt-4o'),
       system: 'You are a professional Japanese editor. Return content in Markdown.',
-      prompt: `以下の概要を読み、指定のテンプレートに沿って日本語で記事ドラフトを作成してください。テンプレート内の {{placeholder}} を適切な内容で置き換えてください。\n\n## テンプレート\n${format.template}\n\n## 概要\n${overview}`,
+      prompt: `以下の概要を読み、指定のテンプレートに沿って日本語で記事ドラフトを作成してください。テンプレート内の {{placeholder}} を適切な内容で置き換えてください。\n\n## テンプレート\n${format.template}\n\n## 概要\n${ov}`,
       temperature: 0.8,
       maxTokens: 2048,
     });

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
       maxTokens: 2048,
     });
 
-    return result.toDataStreamResponse();
+    return result.toTextStreamResponse();
   } catch (e: unknown) {
     console.error(e);
     return new Response('Internal Error', { status: 500 });

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,0 +1,35 @@
+import { streamText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { defaultFormats } from '@/lib/formats';
+
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  try {
+    const { overview, formatId } = (await req.json()) as {
+      overview: string;
+      formatId: string;
+    };
+
+    if (typeof overview !== 'string' || overview.length < 10) {
+      return new Response('overview must be at least 10 characters', {
+        status: 400,
+      });
+    }
+
+    const format = defaultFormats.find((f) => f.id === formatId) ?? defaultFormats[0];
+
+    const result = streamText({
+      model: openai('gpt-4o'),
+      system: 'You are a professional Japanese editor. Return content in Markdown.',
+      prompt: `以下の概要を読み、指定のテンプレートに沿って日本語で記事ドラフトを作成してください。テンプレート内の {{placeholder}} を適切な内容で置き換えてください。\n\n## テンプレート\n${format.template}\n\n## 概要\n${overview}`,
+      temperature: 0.8,
+      maxTokens: 2048,
+    });
+
+    return result.toDataStreamResponse();
+  } catch (e: unknown) {
+    console.error(e);
+    return new Response('Internal Error', { status: 500 });
+  }
+}

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useCompletion } from '@ai-sdk/react';
+import { defaultFormats } from '@/lib/formats';
+import { useState } from 'react';
+
+export default function ArticlePage() {
+  const [formatId, setFormatId] = useState(defaultFormats[0].id);
+  const { completion, input, handleInputChange, handleSubmit, isLoading, error } =
+    useCompletion({
+      api: '/api/generate',
+      body: { formatId },
+      streamProtocol: 'text',
+    });
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 flex flex-col gap-6">
+      <h1 className="text-2xl font-bold">記事生成</h1>
+
+      <label className="flex flex-col gap-2">
+        <span>フォーマット</span>
+        <select
+          value={formatId}
+          onChange={(e) => setFormatId(e.target.value)}
+          className="border p-2"
+        >
+          {defaultFormats.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <label className="flex flex-col gap-2">
+          <span>概要 (10文字以上)</span>
+          <textarea
+            className="border p-2 h-32"
+            value={input}
+            onChange={handleInputChange}
+            minLength={10}
+            required
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="bg-black text-white px-4 py-2 self-start disabled:opacity-50"
+        >
+          {isLoading ? '生成中...' : '生成'}
+        </button>
+      </form>
+
+      {error && <p className="text-red-600">{error.message}</p>}
+
+      {completion && (
+        <section className="border p-4 whitespace-pre-wrap bg-gray-50 dark:bg-gray-800">
+          {completion}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -7,8 +7,11 @@ export default function ArticlePage() {
   const [formatId, setFormatId] = useState(defaultFormats[0].id);
   const { completion, input, handleInputChange, handleSubmit, isLoading, error } =
     useCompletion({
+      headers: {
+        'Content-Type': 'application/json',
+      },
       api: '/api/generate',
-      body: { formatId, prompt: input },
+      body: { formatId },
       streamProtocol: 'text',
     });
 

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -8,7 +8,7 @@ export default function ArticlePage() {
   const { completion, input, handleInputChange, handleSubmit, isLoading, error } =
     useCompletion({
       api: '/api/generate',
-      body: { formatId },
+      body: { formatId, prompt: input },
       streamProtocol: 'text',
     });
 

--- a/src/lib/formats.ts
+++ b/src/lib/formats.ts
@@ -1,0 +1,23 @@
+export type Format = {
+  id: string;
+  name: string;
+  template: string;
+};
+
+export const defaultFormats: Format[] = [
+  {
+    id: 'blog',
+    name: 'ブログ',
+    template: `# ブログ記事テンプレート\n\n## タイトル\n{{title}}\n\n## リード文\n{{lead}}\n\n## 見出し1\n{{heading1}}\n\n本文\n\n## 見出し2\n{{heading2}}\n\n本文\n\n## まとめ\n{{conclusion}}`,
+  },
+  {
+    id: 'news',
+    name: 'ニュース',
+    template: `# ニューステンプレート\n\n## 見出し\n{{headline}}\n\n### 日時・場所\n{{datetime_place}}\n\n### 本文\n{{body}}\n\n### 背景\n{{background}}\n\n### 今後の見通し\n{{outlook}}`,
+  },
+  {
+    id: 'seo',
+    name: 'SEO ランディング',
+    template: `# SEO ランディングページテンプレート\n\n## タイトル (キーワード含む)\n{{title}}\n\n## リード文\n{{lead}}\n\n## 課題提起\n{{problem}}\n\n## 解決策\n{{solution}}\n\n## 具体例\n{{examples}}\n\n## CTA\n{{cta}}`,
+  },
+];


### PR DESCRIPTION
## 目的
要件定義書 (docs/requirements.md) の R1 記事生成機能を MVP として実装しました。

## 変更概要
### フロントエンド
- `src/app/article/page.tsx`
  - `useCompletion` フックでストリーミング生成
  - フォーマット選択 UI・概要入力フォームを実装

### API (Edge)
- `src/app/api/generate/route.ts`
  - `streamText` + `toDataStreamResponse` で SSE 返却
  - 入力バリデーション (概要10文字以上)

### ライブラリ
- `src/lib/formats.ts` … デフォルトフォーマット3種 (ブログ/ニュース/SEO)

### ドキュメント
- `docs/ai-sdk.md` … Vercel AI SDK 利用ガイド追加
- `.env.example` 追加

### 依存追加
- `ai`, `@ai-sdk/openai`, `@ai-sdk/react`

## 動作確認手順
```bash
npm i
cp .env.example .env.local  # OPENAI_API_KEY を設定
npm run dev
# http://localhost:3000/article にアクセスし、概要を入力 → 生成確認
```

## 補足
- R1-03 のストリーミング表示を実装済み
- 履歴保存などは未実装 (今後 R4 対応時に追加予定)

ご確認よろしくお願いいたします。